### PR TITLE
correcting Arabic and Persian word counting

### DIFF
--- a/src/intro.js
+++ b/src/intro.js
@@ -1,4 +1,3 @@
-
 var isMac = /Mac/.test(navigator.platform);
 
 var shortcuts = {
@@ -335,9 +334,9 @@ function _toggleLine(cm, name) {
 }
 
 
-/* The right word count in respect for CJK. */
+/* The right word count in respect for CJK, Arabic and Persian. */
 function wordCount(data) {
-  var pattern = /[a-zA-Z0-9_\u0392-\u03c9]+|[\u4E00-\u9FFF\u3400-\u4dbf\uf900-\ufaff\u3040-\u309f\uac00-\ud7af]+/g;
+  var pattern = /[a-zA-Z0-9_\u0392-\u03c9ـ\u0600-\u06FF]+|[\u4E00-\u9FFF\u3400-\u4dbf\uf900-\ufaff\u3040-\u309f\uac00-\ud7af]+/g;
   var m = data.match(pattern);
   var count = 0;
   for (var i = 0; i < m.length; i++) {


### PR DESCRIPTION
matching Arabic and Persian words. [test in regexpal.com](http://regexpal.com/?flags=g&regex=[a-zA-Z0-9_u0392-u03c9%D9%80u0600-u06FF]%2B|[u4E00-u9FFFu3400-u4dbfuf900-ufaffu3040-u309fuac00-ud7af]%2B&input=salam%20salam%20%D8%B3%D9%84%D8%A7%D9%85%20salam%0A%0A%D8%A7%DB%8C%D9%86%20%D8%AE%DB%8C%D9%84%DB%8C%20%D8%AE%D9%88%D8%A8%D9%87!%20%DA%A9%DA%86%D9%84%20%DA%A9%D9%84%D8%A7%DA%86%D9%87.)
