### PR TITLE
Fixed bug when in preview mode, half of the scroll bar is shown.

### DIFF
--- a/editor.css
+++ b/editor.css
@@ -102,7 +102,6 @@
 }
 .editor-preview {
   position: absolute;
-  padding: 4px;
   width: 100%;
   height: 100%;
   top: 0;


### PR DESCRIPTION
Changed the editor.css, removed the padding:4px; from editor-preview class for the scroll-bar to be showed right.
