### PR TITLE
Adding 'togglePreview' to export

### DIFF
--- a/src/editor.js
+++ b/src/editor.js
@@ -220,6 +220,7 @@ Editor.drawImage = drawImage;
 Editor.undo = undo;
 Editor.redo = redo;
 Editor.toggleFullScreen = toggleFullScreen;
+Editor.togglePreview = togglePreview;
 
 /**
  * Bind instance methods for exports.
@@ -253,4 +254,7 @@ Editor.prototype.redo = function() {
 };
 Editor.prototype.toggleFullScreen = function() {
   toggleFullScreen(this);
+};
+Editor.prototype.togglePreview = function() {
+  togglePreview(this);
 };


### PR DESCRIPTION
Hi there,

I was trying to setup a custom toolbar but was unable to add the togglePreview option because it wasn't exported like the other options.

I'm not sure if this is the intended functionality, in case it is you may just ignore this pull request.
