### PR TITLE
Fix an issue about bold/italic toggling with CJK

### DIFF
--- a/src/intro.js
+++ b/src/intro.js
@@ -139,8 +139,8 @@ function toggleBold(editor) {
     start = text.slice(0, startPoint.ch);
     end = text.slice(startPoint.ch);
 
-    start = start.replace(/^(.*)?(\*|\_){2}(\S+.*)?$/, '$1$3');
-    end = end.replace(/^(.*\S+)?(\*|\_){2}(\s+.*)?$/, '$1$3');
+    start = start.replace(/^(.*)?(\*|\_){2}(.*)?$/, '$1$3');
+    end = end.replace(/^(.*)?(\*|\_){2}(.*)?$/, '$1$3');
     startPoint.ch -= 2;
     endPoint.ch -= 2;
     cm.setLine(startPoint.line, start + end);
@@ -174,8 +174,8 @@ function toggleItalic(editor) {
     start = text.slice(0, startPoint.ch);
     end = text.slice(startPoint.ch);
 
-    start = start.replace(/^(.*)?(\*|\_)(\S+.*)?$/, '$1$3');
-    end = end.replace(/^(.*\S+)?(\*|\_)(\s+.*)?$/, '$1$3');
+    start = start.replace(/^(.*)?(\*|\_)(.*)?$/, '$1$3');
+    end = end.replace(/^(.*)?(\*|\_)(.*)?$/, '$1$3');
     startPoint.ch -= 1;
     endPoint.ch -= 1;
     cm.setLine(startPoint.line, start + end);


### PR DESCRIPTION
Before this change, we can only remove bold attribute of whole words.

```
This is a **bold** text
```

We select the word 'bold', click the 'bold' button and everything is okay.

```
This is a bold text
```

However, in Chinese/Japanese/Korean we don't have spaces between words.

```
No**spaces**between words in CJK
```

Therefore, selecting 'spaces' and clicking the 'bold' button will not work properly. It becomes

```
Nospaces**between words in CJK
```

I fixed this and it worked well for both Latin and CJK characters. Please take a look if possible. Thanks!
