### PR TITLE
Fix for Bower `invalid meta`

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,8 +7,7 @@
   ],
   "description": "A markdown editor",
   "main": [
-    "src/editor.js",
-    "src/intro.js"
+    "src/editor.js"
   ],
   "moduleType": [
     "globals"

--- a/bower.json
+++ b/bower.json
@@ -6,7 +6,10 @@
     "Hsiaoming Yang <me@lepture.com>"
   ],
   "description": "A markdown editor",
-  "main": "editor.js",
+  "main": [
+    "src/editor.js",
+    "src/intro.js"
+  ],
   "moduleType": [
     "globals"
   ],


### PR DESCRIPTION
When installing from bower, invalid meta shows i think
because "main" file is not pointed correctly.
