### PR TITLE
Fix padding on editor toolbar

### DIFF
--- a/editor.css
+++ b/editor.css
@@ -29,6 +29,7 @@
 }
 .editor-toolbar {
   position: relative;
+  padding: 0 8px;
   opacity: 0.6;
   -webkit-user-select: none;
   -moz-user-select: none;
@@ -84,8 +85,7 @@
   margin: 0 6px;
 }
 .editor-toolbar a.icon-fullscreen {
-  position: absolute;
-  right: 0;
+  float: right;
 }
 .editor-statusbar {
   border-top: 1px solid #ece9e9;


### PR DESCRIPTION
I made the horizontal padding match up with that of the vertical.

Before:
![editor_padding_before](https://cloud.githubusercontent.com/assets/905317/8321036/ed5ab2d8-19ef-11e5-847e-4b8415534728.png)
After:
![editor_padding_after](https://cloud.githubusercontent.com/assets/905317/8321037/f0024c3a-19ef-11e5-9a60-8a85ca95fabc.png)

(Screenshots are from [rationalfiction.io](http://rationalfiction.io), which is where I first noticed the discrepancy.)